### PR TITLE
Add: basic syntax highlighting for multiple languages

### DIFF
--- a/frontend/vite-project/src/App.jsx
+++ b/frontend/vite-project/src/App.jsx
@@ -899,15 +899,18 @@ const App = () => {
               </span>
             </div>
             <div style={{ position: "relative", height: "calc(100% - 40px)" }}>
+            
+            {/* Changed from defaultLanguage to language */}
+             {/* Defaultlanguage prop only sets the language when the editor first loads and doesn't update it afterward. */}
             <Editor
               height="100%"
-              defaultLanguage={currentFileLanguage}
-              value={currentFileContent || code}
+              language={currentFileLanguage} 
+              value={currentFileContent || code} 
               onChange={handleChange}
               onMount={handleEditorOnMount}
               theme={theme === "dark" ? "vs-dark" : "vs-light"}
               options={{
-                minimap: { enabled: false },
+                minimap:{ enabled: false },
                 fontSize: 14,
               }}
             />


### PR DESCRIPTION
HI
added syntax highligting for multiple languages 
default field was the issue researched about the way and chose the better way replacing with language field to change acc to current language! 
Do ping me if any change/update required!