### PR TITLE
Removed unnecessary "Reconnecting…" banner from editor

### DIFF
--- a/frontend/vite-project/src/App.jsx
+++ b/frontend/vite-project/src/App.jsx
@@ -832,12 +832,14 @@ const App = () => {
           <QueryClientProvider client={queryClient}>
       <TooltipProvider>
         <Toaster />
-        {/* Reconnecting indicator */}
+        {/* Reconnecting indicator
         {!isConnected && (
           <div className="reconnecting-overlay">
             Reconnecting…
           </div>
-        )}
+        )} 
+        */}       
+        
     <>
       <ResizableLayout
         sidebar={


### PR DESCRIPTION
This PR fixes the issue where an unnecessary “Reconnecting…” div was displayed on top of the editor during socket reconnections.